### PR TITLE
fix utf8

### DIFF
--- a/transfer.py
+++ b/transfer.py
@@ -98,10 +98,10 @@ def process_all_files(service, callback=None, callback_args=None, minimum_prefix
                 #pprint.pprint(item)
                 if item['kind'] == 'drive#file':
                     if current_prefix[:len(minimum_prefix)] == minimum_prefix:
-                        print('File: {} ({}, {})'.format(item['title'].encode('utf-8', 'replace'), current_prefix, item['id']))
+                        print(u'File: {} ({}, {})'.format(item['title'], current_prefix, item['id']))
                         callback(service, item, current_prefix, **callback_args)
                     if item['mimeType'] == 'application/vnd.google-apps.folder':
-                        print('Folder: {} ({}, {})'.format(item['title'], current_prefix, item['id']))
+                        print(u'Folder: {} ({}, {})'.format(item['title'], current_prefix, item['id']))
                         next_prefix = current_prefix + [item['title']]
                         comparison_length = min(len(next_prefix), len(minimum_prefix))
                         if minimum_prefix[:comparison_length] == next_prefix[:comparison_length]:


### PR DESCRIPTION
Hello.
There was a with your python. when there are folder with non-english names.

This is the bug:

  File "transfer.py", line 104, in process_all_files
    print('Folder: {} ({}, {})'.format(item['title'], current_prefix, item['id']))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-5: ordinal not in range(128)

I have tested it, and fixed it.

Please  accept the pull request.
