### PR TITLE
Feature/using six

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NOTE: The Google Drive API does not allow suppressing notifications for change o
 ### Setup
 
     git clone https://github.com/davidstrauss/google-drive-recursive-ownership
-    pip install --upgrade google-api-python-client oauth2client
+    pip install --upgrade google-api-python-client oauth2client six
 
 ### Usage
 

--- a/transfer.py
+++ b/transfer.py
@@ -1,13 +1,16 @@
 #!/usr/bin/python
 
+import sys
+import pprint
+import os
+
+import six
 import httplib2
 import googleapiclient.discovery
 import googleapiclient.http
 import googleapiclient.errors
 import oauth2client.client
-import sys
-import pprint
-import os
+
 
 def get_drive_service():
     OAUTH2_SCOPE = 'https://www.googleapis.com/auth/drive'
@@ -16,10 +19,7 @@ def get_drive_service():
     flow.redirect_uri = oauth2client.client.OOB_CALLBACK_URN
     authorize_url = flow.step1_get_authorize_url()
     print('Use this link for authorization: {}'.format(authorize_url))
-    if sys.version_info[0] > 2:
-        code = input('Verification code: ').strip()
-    else:
-        code = raw_input('Verification code: ').strip()
+    code = six.moves.input('Verification code: ').strip()
     credentials = flow.step2_exchange(code)
     http = httplib2.Http()
     credentials.authorize(http)
@@ -120,14 +120,9 @@ def process_all_files(service, callback=None, callback_args=None, minimum_prefix
 
 
 def main():
-    if sys.version_info[0] > 2:
-        minimum_prefix = sys.argv[1]
-        new_owner = sys.argv[2]
-        show_already_owned = False if len(sys.argv) > 3 and sys.argv[3] == 'false' else True
-    else:
-        minimum_prefix = sys.argv[1].decode('utf-8')
-        new_owner = sys.argv[2].decode('utf-8')
-        show_already_owned = False if len(sys.argv) > 3 and sys.argv[3].decode('utf-8') == 'false' else True
+    minimum_prefix = six.text_type(sys.argv[1])
+    new_owner = six.text_type(sys.argv[2])
+    show_already_owned = False if len(sys.argv) > 3 and six.text_type(sys.argv[3]) == 'false' else True
     print('Changing all files at path "{}" to owner "{}"'.format(minimum_prefix, new_owner))
     minimum_prefix_split = minimum_prefix.split(os.path.sep)
     print('Prefix: {}'.format(minimum_prefix_split))


### PR DESCRIPTION
- Simplified script to use Python's compatibility library `six`.  It eliminates the need to differentiate Python 2 and 3 when taking user input and parsing `sys.argv`.
     - Python 3 linters will no longer complain about unresolved references to `raw_input` or `str.decode('utf-8')`
 - Called `six` out as a required package in the `README.md`'s pip installation instructions.
     - `six` is already a requirement of `google-api-python-client` ([source](https://github.com/googleapis/google-api-python-client/blob/master/setup.py#L43)), so it's not actually expanding required packages
 - Organized imports at top of `transport.py` by standard libraries vs 3rd party packages