### PR TITLE
Fix backslash hidden on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Next, if `transfer.py` is contained in a folder listed in your system's `PATH` t
 
     python  transfer.py  PATH-PREFIX  NEW-OWNER-EMAIL  SHOW-ALREADY-OWNER
     
- - `PATH-PREFIX` assumes use of "/" or "\" as appropriate for your operating system.
+ - `PATH-PREFIX` assumes use of "`/`" or "`\`" as appropriate for your operating system.
 
    * The `PATH-PREFIX` folder must be in **My Drive** section. For shared folders right click and select _Add to My Drive_.
 


### PR DESCRIPTION
<img width="462" alt="image" src="https://user-images.githubusercontent.com/55806347/209954483-07bf3bed-2678-4a1c-8f6a-561ef669c402.png">
As you can see on the screenshot above, before this change, the `\` was actually hidden on the readme